### PR TITLE
Added swagger to document our API

### DIFF
--- a/RC-SpeechToText/Controllers/Videos/VideoController.cs
+++ b/RC-SpeechToText/Controllers/Videos/VideoController.cs
@@ -18,12 +18,6 @@ namespace RC_SpeechToText.Controllers
         }
 
         [HttpPost("[action]")]
-        public int Create(Video video)
-        {
-            return videoObj.AddVideo(video);
-        }
-
-        [HttpPost("[action]")]
         public int Create(Video video, Video path)
         {
             return videoObj.AddVideo(video, path);

--- a/RC-SpeechToText/RC-SpeechToText.csproj
+++ b/RC-SpeechToText/RC-SpeechToText.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="NAudio" Version="1.8.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>
 

--- a/RC-SpeechToText/Startup.cs
+++ b/RC-SpeechToText/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SpaServices.Webpack;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace RC_SpeechToText
 {
@@ -23,6 +24,12 @@ namespace RC_SpeechToText
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
+
+            // Register the Swagger generator, defining 1 or more Swagger documents
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new Info { Title = "SearchAV API", Version = "v1" });
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -43,6 +50,16 @@ namespace RC_SpeechToText
             }
 
             app.UseStaticFiles();
+
+            // Enable middleware to serve generated Swagger as a JSON endpoint.
+            app.UseSwagger();
+
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
+            // specifying the Swagger JSON endpoint.
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "SearchAV API V1");
+            });
 
             app.UseMvc(routes =>
             {


### PR DESCRIPTION
**Go to /swagger to see the docs**

Automatically documents our api routes and models

Ex: 
![image](https://user-images.githubusercontent.com/13418355/49819012-4f9a9600-fd42-11e8-805e-98e057ec9a4e.png)

![image](https://user-images.githubusercontent.com/13418355/49819047-617c3900-fd42-11e8-90ff-429339e6992c.png)
